### PR TITLE
Separate styles from heading level in typography

### DIFF
--- a/lib/components/typography/package-lock.json
+++ b/lib/components/typography/package-lock.json
@@ -1,0 +1,25 @@
+{
+  "name": "@boclips-ui/typography",
+  "version": "2.2.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@boclips-ui/media-breakpoints": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@boclips-ui/media-breakpoints/-/media-breakpoints-2.0.2.tgz",
+      "integrity": "sha512-5cfukdzWfm2iYSZjl37A81nUD7JNL0r70SrHVBcpQ5g2/Ka2chqg1GW0uPpkUTLJeaAoqdQy94MVIy7GQWSevQ=="
+    },
+    "@boclips-ui/ts-config": {
+      "version": "1.0.15",
+      "dev": true
+    },
+    "@boclips-ui/use-media-breakpoints": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@boclips-ui/use-media-breakpoints/-/use-media-breakpoints-2.0.3.tgz",
+      "integrity": "sha512-4ibpvyEP5y9tBfjNvZV/bwwXSZ5ulyaQOReAIOudfq0X06Av9dNR7HWuv7U1OYsKf+Y1mNxGNkJozMynx58BbA==",
+      "requires": {
+        "@boclips-ui/media-breakpoints": "^2.0.2"
+      }
+    }
+  }
+}

--- a/lib/components/typography/package.json
+++ b/lib/components/typography/package.json
@@ -22,5 +22,9 @@
     "access": "public"
   },
   "license": "SEE LICENSE IN LICENSE",
-  "gitHead": "16303107676919ce6cc5b925cb6cece5974a00a2"
+  "gitHead": "16303107676919ce6cc5b925cb6cece5974a00a2",
+  "dependencies": {
+    "@boclips-ui/media-breakpoints": "^2.0.2",
+    "@boclips-ui/use-media-breakpoints": "^2.0.3"
+  }
 }

--- a/lib/components/typography/src/body/body.test.tsx
+++ b/lib/components/typography/src/body/body.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { render } from "@testing-library/react";
-import { Body } from "./body";
+import { Body } from ".";
 
 describe("body", () => {
   it("can set the underlying component with a prop", () => {

--- a/lib/components/typography/src/body/index.tsx
+++ b/lib/components/typography/src/body/index.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import c from "classnames";
 
 // @ts-ignore
-import s from "./styles.module.less";
+import s from "../styles.module.less";
 
 export interface Props<T extends React.ElementType>
   extends React.DetailedHTMLProps<

--- a/lib/components/typography/src/headers/Base.test.tsx
+++ b/lib/components/typography/src/headers/Base.test.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import { Base } from "./Base";
+import { resizeToTablet } from "../testSupport/resizeTo";
+
+describe("Base", () => {
+  it("renders correct heading level", () => {
+    const h1 = render(<Base size="lg" as="h1" />);
+    const h2 = render(<Base size="lg" as="h2" />);
+
+    expect(h1.getByRole("heading", { level: 1 })).toBeVisible();
+    expect(h2.getByRole("heading", { level: 2 })).toBeVisible();
+  });
+
+  it("renders correct size class name with simple size", () => {
+    const wrapper = render(<Base size="lg" as="h1" />);
+    expect(wrapper.container.firstChild).toHaveClass("l");
+  });
+
+  it("renders correct size class for device size", () => {
+    resizeToTablet();
+
+    const wrapper = render(
+      <Base size={{ mobile: "sm", tablet: "md" }} as="h1" />
+    );
+
+    expect(wrapper.container.firstChild).toHaveClass("m");
+  });
+
+  it("renders correct weight classname when size is xs", () => {
+    const wrapper = render(<Base size="xs" weight="regular" as="h1" />);
+
+    expect(wrapper.container.firstChild).toHaveClass("xs");
+    expect(wrapper.container.firstChild).toHaveClass("regular");
+  });
+
+  it("renders correct nested size and weight class names for device size", () => {
+    resizeToTablet();
+
+    const wrapper = render(
+      <Base
+        size={{ mobile: "sm", tablet: { size: "xs", weight: "medium" } }}
+        as="h1"
+      />
+    );
+
+    expect(wrapper.container.firstChild).toHaveClass("xs");
+    expect(wrapper.container.firstChild).toHaveClass("medium");
+  });
+});

--- a/lib/components/typography/src/headers/Base.tsx
+++ b/lib/components/typography/src/headers/Base.tsx
@@ -1,0 +1,75 @@
+import React from "react";
+import { useMediaBreakPoint } from "@boclips-ui/use-media-breakpoints";
+import c from "classnames";
+import { findSizeFromCurrentDevice } from "./utils/sizeResolver";
+
+// @ts-ignore
+import s from "./style.module.less";
+
+import {
+  AsProps,
+  VariableHeaderSize,
+  HeaderSizeWithWeight,
+  HTMLHeadingProps,
+  isHeaderSizeWithWeight,
+  HeaderSize,
+} from "./types";
+
+/**
+ * This allows us to set weight only when the size prop is set to xs
+ */
+export type HeaderProps = (HeaderSizeWithWeight | Partial<VariableHeaderSize>) &
+  HTMLHeadingProps;
+
+type InternalProps = (HeaderSizeWithWeight | VariableHeaderSize) &
+  HTMLHeadingProps &
+  AsProps;
+
+export const Base = ({
+  children,
+  size,
+  as,
+  className,
+  ...rest
+}: React.PropsWithChildren<InternalProps>): React.ReactElement => {
+  const Component = as;
+  const currentBreakpoint = useMediaBreakPoint();
+
+  const resolvedSize = React.useMemo(
+    () =>
+      typeof size === "string"
+        ? size
+        : findSizeFromCurrentDevice(size, currentBreakpoint),
+    [size, currentBreakpoint]
+  );
+
+  return (
+    <Component
+      className={c(
+        s[resolveNestedSize(resolvedSize)],
+        s[resolveNestedWeight(rest, resolvedSize)],
+        s.header,
+        className
+      )}
+      // eslint-disable-next-line react/jsx-props-no-spreading
+      {...rest}
+    >
+      {children}
+    </Component>
+  );
+};
+
+const resolveNestedSize = (
+  size: HeaderSize | HeaderSizeWithWeight | undefined
+) => (isHeaderSizeWithWeight(size) ? size.size : size);
+
+const resolveNestedWeight = (
+  props: any,
+  size: HeaderSize | HeaderSizeWithWeight | undefined
+) => {
+  if ("weight" in props) {
+    return props.weight;
+  }
+
+  return isHeaderSizeWithWeight(size) ? size.weight : "medium";
+};

--- a/lib/components/typography/src/headers/index.tsx
+++ b/lib/components/typography/src/headers/index.tsx
@@ -1,83 +1,83 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import React from "react";
-import c from "classnames";
-
-// @ts-ignore
-import s from "./styles.module.less";
-
-type HeaderProps = React.DetailedHTMLProps<
-  React.HTMLAttributes<HTMLHeadingElement>,
-  HTMLHeadingElement
->;
+import { Base, HeaderProps } from "./Base";
 
 export const H1: React.FC<HeaderProps> = ({
   children,
-  className,
+  size = "xl",
   ...rest
 }: React.PropsWithChildren<HeaderProps>) => {
   return (
-    <h1 className={c(s.base, className)} {...rest}>
+    <Base as="h1" size={size} {...rest}>
       {children}
-    </h1>
+    </Base>
   );
 };
 
 export const H2: React.FC<HeaderProps> = ({
   children,
-  className,
+  size = "lg",
   ...rest
 }: React.PropsWithChildren<HeaderProps>) => {
   return (
-    <h2 className={c(s.base, className)} {...rest}>
+    <Base as="h2" size={size} {...rest}>
       {children}
-    </h2>
+    </Base>
   );
 };
 
 export const H3: React.FC<HeaderProps> = ({
   children,
-  className,
+  size = "md",
   ...rest
 }: React.PropsWithChildren<HeaderProps>) => {
   return (
-    <h3 className={c(s.base, className)} {...rest}>
+    <Base as="h3" size={size} {...rest}>
       {children}
-    </h3>
+    </Base>
   );
 };
 
 export const H4: React.FC<HeaderProps> = ({
   children,
-  className,
+  size = "sm",
   ...rest
 }: React.PropsWithChildren<HeaderProps>) => {
   return (
-    <h4 className={c(s.base, className)} {...rest}>
+    <Base as="h4" size={size} {...rest}>
       {children}
-    </h4>
+    </Base>
   );
 };
 
 export const H5: React.FC<HeaderProps> = ({
   children,
-  className,
+  size,
   ...rest
 }: React.PropsWithChildren<HeaderProps>) => {
-  return (
-    <h5 className={c(s.base, className)} {...rest}>
+  return size ? (
+    <Base as="h5" size={size} {...rest}>
       {children}
-    </h5>
+    </Base>
+  ) : (
+    <Base as="h5" size="xs" weight="medium" {...rest}>
+      {children}
+    </Base>
   );
 };
 
 export const H6: React.FC<HeaderProps> = ({
   children,
-  className,
+  size,
   ...rest
 }: React.PropsWithChildren<HeaderProps>) => {
-  return (
-    <h6 className={c(s.base, className)} {...rest}>
+  return size ? (
+    <Base as="h6" size={size} {...rest}>
       {children}
-    </h6>
+    </Base>
+  ) : (
+    <Base as="h6" size="xs" weight="regular" {...rest}>
+      {children}
+    </Base>
   );
 };

--- a/lib/components/typography/src/headers/style.module.less
+++ b/lib/components/typography/src/headers/style.module.less
@@ -1,0 +1,27 @@
+.header {
+  composes: base from "../styles.module.less";
+
+  &.regular {
+    font-weight: 400;
+  }
+
+  &.xl {
+    font-size: 2.5rem;
+  }
+
+  &.l {
+    font-size: 2rem;
+  }
+
+  &.m {
+    font-size: 1.5rem;
+  }
+
+  &.s {
+    font-size: 1.25rem;
+  }
+
+  &.xs {
+    font-size: 1.125rem;
+  }
+}

--- a/lib/components/typography/src/headers/types.tsx
+++ b/lib/components/typography/src/headers/types.tsx
@@ -1,0 +1,43 @@
+import { Breakpoint } from "@boclips-ui/media-breakpoints";
+
+export type HeaderSize = "xs" | "sm" | "md" | "lg" | "xl";
+
+export type DeviceAwareHeaderSize = {
+  [name in Breakpoint]?: HeaderSize | HeaderSizeWithWeight;
+};
+
+export interface HeaderSizeWithWeight {
+  size: "xs";
+  weight: "regular" | "medium";
+}
+
+export interface VariableHeaderSize {
+  size: HeaderSize | DeviceAwareHeaderSize;
+}
+
+export interface AsProps {
+  as: "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
+}
+
+export type HTMLHeadingProps = React.DetailedHTMLProps<
+  React.HTMLAttributes<HTMLHeadingElement>,
+  HTMLHeadingElement
+>;
+
+export function isHeaderSizeWithWeight(
+  size: HeaderSizeWithWeight | HeaderSize | undefined
+): size is HeaderSizeWithWeight {
+  if (!size) {
+    return false;
+  }
+
+  if (typeof size === "string") {
+    return false;
+  }
+
+  if (size.size && size.weight) {
+    return true;
+  }
+
+  return false;
+}

--- a/lib/components/typography/src/headers/utils/sizeResolver.test.ts
+++ b/lib/components/typography/src/headers/utils/sizeResolver.test.ts
@@ -1,0 +1,43 @@
+import { breakpoints } from "@boclips-ui/media-breakpoints";
+import { DeviceAwareHeaderSize } from "../types";
+import { findSizeFromCurrentDevice } from "./sizeResolver";
+
+describe("size resolver", () => {
+  it("returns the size that exactly matches the device", () => {
+    const sizes: DeviceAwareHeaderSize = {
+      mobile: "s",
+      tablet: "m",
+      desktop: "l",
+    };
+
+    expect(findSizeFromCurrentDevice(sizes, breakpoints.mobile)).toEqual("s");
+    expect(findSizeFromCurrentDevice(sizes, breakpoints.tablet)).toEqual("m");
+    expect(findSizeFromCurrentDevice(sizes, breakpoints.desktop)).toEqual("l");
+  });
+
+  it("returns the size of the next matching breakpoint if no direct match", () => {
+    const sizes: DeviceAwareHeaderSize = {
+      mobile: "s",
+      tablet: "m",
+    };
+
+    expect(findSizeFromCurrentDevice(sizes, breakpoints.desktop)).toEqual("m");
+  });
+
+  it("returns size of only breakpoints that are equal or smaller than the current device", () => {
+    const sizes: DeviceAwareHeaderSize = {
+      mobile: "s",
+      desktop: "m",
+    };
+
+    expect(findSizeFromCurrentDevice(sizes, breakpoints.tablet)).toEqual("s");
+  });
+
+  it("returns null if no matching size found", () => {
+    const sizes: DeviceAwareHeaderSize = { tablet: "s", desktop: "l" };
+
+    expect(
+      findSizeFromCurrentDevice(sizes, breakpoints.mobile)
+    ).toBeUndefined();
+  });
+});

--- a/lib/components/typography/src/headers/utils/sizeResolver.ts
+++ b/lib/components/typography/src/headers/utils/sizeResolver.ts
@@ -1,0 +1,29 @@
+import { Breakpoint, breakpoints, Device } from "@boclips-ui/media-breakpoints";
+import {
+  HeaderSizeWithWeight,
+  HeaderSize,
+  DeviceAwareHeaderSize,
+} from "../types";
+
+export const findSizeFromCurrentDevice = (
+  deviceAwareSizes: DeviceAwareHeaderSize,
+  currentDevice: Device
+): HeaderSize | HeaderSizeWithWeight | undefined => {
+  const sizeMatchingCurrentDevice = deviceAwareSizes[currentDevice.type];
+
+  if (sizeMatchingCurrentDevice) {
+    return sizeMatchingCurrentDevice;
+  }
+
+  const sortedDevices = Object.keys(deviceAwareSizes)
+    .map((device) => breakpoints[device as Breakpoint])
+    .filter((device) => device.maxWidth <= currentDevice.maxWidth)
+    .sort((a, b) => b.maxWidth - a.maxWidth);
+
+  if (sortedDevices.length > 0) {
+    const nextLargestDevice = sortedDevices[0];
+    return deviceAwareSizes[nextLargestDevice.type];
+  }
+
+  return undefined;
+};

--- a/lib/components/typography/src/styles.module.less
+++ b/lib/components/typography/src/styles.module.less
@@ -1,55 +1,29 @@
 .base {
-    font-family: "Rubik", Helvetica Neue, Helvetica, Arial, sans-serif;
-    letter-spacing: 0.0012em;
-    line-height: 150%;
-    font-weight: 500;
+  font-family: "Rubik", Helvetica Neue, Helvetica, Arial, sans-serif;
+  letter-spacing: 0.0012em;
+  line-height: 150%;
+  font-weight: 500;
 
-    &.body {
-        font-weight: normal;
-        font-size: 1rem;
+  &.body {
+    font-weight: normal;
+    font-size: 1rem;
 
-        &.small {
-            font-size: 0.875rem;
-        }
-
-        &.medium {
-            font-weight: 500;
-        }
+    &.small {
+      font-size: 0.875rem;
     }
 
-    &.title1 {
-        font-weight: 700;
-        font-size: 1.125rem;
+    &.medium {
+      font-weight: 500;
     }
+  }
 
-
-    &.title2 {
-        font-weight: 700;
-        font-size: 1rem;
-    }
-}
-
-h1.base {
-    font-size: 2.5rem;
-}
-
-h2.base {
-    font-size: 2rem;
-}
-
-h3.base {
-    font-size: 1.5rem;
-}
-
-h4.base {
-    font-size: 1.25rem;
-}
-
-h5.base, h6.base {
+  &.title1 {
+    font-weight: 700;
     font-size: 1.125rem;
-}
+  }
 
-h6.base {
-    font-weight: 400;
+  &.title2 {
+    font-weight: 700;
+    font-size: 1rem;
+  }
 }
-

--- a/lib/components/typography/src/testSupport/resizeTo.ts
+++ b/lib/components/typography/src/testSupport/resizeTo.ts
@@ -1,0 +1,27 @@
+import { breakpoints } from "@boclips-ui/media-breakpoints";
+
+// This should be it's own package
+function resizeTo(width: number, height: number): void {
+  const resizeEvent = document.createEvent("Event");
+  resizeEvent.initEvent("resize", true, true);
+
+  // @ts-ignore
+  window.innerWidth = width;
+  // @ts-ignore
+  window.innerHeight = height;
+  window.dispatchEvent(resizeEvent);
+}
+
+export function resizeToMobile(height = 1024) {
+  resizeTo(breakpoints.mobile.maxWidth - 1, height);
+}
+
+export function resizeToTablet(height = 1024) {
+  resizeTo(breakpoints.tablet.maxWidth - 1, height);
+}
+
+export function resizeToDesktop(height = 1024) {
+  resizeTo(breakpoints.desktop.maxWidth - 1, height);
+}
+
+export default resizeTo;

--- a/lib/components/typography/storybook/index.stories.tsx
+++ b/lib/components/typography/storybook/index.stories.tsx
@@ -14,6 +14,34 @@ const Template: Story = () => (
     <Typography.H4>Hello, this is a H4</Typography.H4>
     <Typography.H5>Hello, this is a H5</Typography.H5>
     <Typography.H6>Hello, this is a H6</Typography.H6>
+
+    <hr />
+    <Typography.H1 size="sm" id="hello">
+      Hello, this is a small H1
+    </Typography.H1>
+    <Typography.H2 size="xs" weight="regular">
+      Hello, this is an xs H2
+    </Typography.H2>
+    <Typography.H3 size="lg">Hello, this is a l H3</Typography.H3>
+    <Typography.H4 size="xl">Hello, this is a xl H4</Typography.H4>
+    <Typography.H5
+      className="hello"
+      size={{ mobile: "md", tablet: "lg", desktop: "xl" }}
+    >
+      Hello, this is a dynamic H5
+    </Typography.H5>
+    <Typography.H6
+      size={{
+        mobile: "xl",
+        tablet: { size: "xs", weight: "medium" },
+        desktop: { size: "xs", weight: "regular" },
+      }}
+    >
+      Hello, this is a dynamic H6
+    </Typography.H6>
+
+    <hr />
+
     <Typography.Title1 className="hello" as="div">
       Hello, this is Title1
     </Typography.Title1>


### PR DESCRIPTION
- We can now pass in a size to typography headers to dictate the style.
  This can also be device aware, and works similarly to tailwind -
  specifying mobile only will affect all screen sizes larger or equal to
  mobile (so all of them).
- For size xs we can also specify a weight, medium or regular. Maybe it
  would have been simpler to do xs-regular as a size. But I got carried
  away with typing this. (can only specify a weight prop if size="xs")

[#181415315]