### PR TITLE
Make input constraints optional

### DIFF
--- a/lib/components/input/src/index.tsx
+++ b/lib/components/input/src/index.tsx
@@ -50,10 +50,7 @@ export const InputText = React.forwardRef(
       inputType,
       height,
       width,
-      constraints = {
-        required: false,
-        minLength: 0,
-      },
+      constraints,
       icon,
       showLabelText = true,
       labelText,
@@ -125,7 +122,7 @@ export const InputText = React.forwardRef(
         {showLabelText && (
           <Typography.Body as="div" className="text-gray-800">
             {labelText}{" "}
-            {!constraints.required && (
+            {constraints?.required === false && (
               <span className={s.optional}>(Optional)</span>
             )}
           </Typography.Body>


### PR DESCRIPTION
- we want to use the Input component in cases where requirement is not needed but we also don't want to show the Optional label
- the previous behaviour only makes sense in a form context

[#183750816]

Signed-off-by: Rafal Lewandowski <rafal@boclips.com>